### PR TITLE
Add pallet-xcm patch with `claim_assets` extrinsic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8005,9 +8005,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0bade2eb6ce40af35a5af150692b4e150638f7f68c15735ab9cdf79650d68e"
+checksum = "d32aa4911002f03a8aebd897e094980e7a9fb25d092e0f8db38e76e1e4f643ee"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -13313,9 +13313,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccecaeae5eca8453760e96fcf65481b19898459971842004732e88cd3570741"
+checksum = "48fa328b87de3466bc38cc9a07244c42c647b7755b81115e1dfeb47cc13fc6e6"
 dependencies = [
  "array-bytes 6.2.2",
  "bounded-collections",

--- a/chain-spec-generator/Cargo.toml
+++ b/chain-spec-generator/Cargo.toml
@@ -26,7 +26,7 @@ pallet-staking = "29.0.0"
 sc-consensus-grandpa = "0.20.0"
 sp-runtime = "32.0.0"
 sp-consensus-beefy = "14.0.0"
-xcm = { package = "staging-xcm", version = "8.0.0" }
+xcm = { package = "staging-xcm", version = "8.0.1" }
 parachains-common = { version = "8.0.0" }
 cumulus-primitives-core = { version = "0.8.0" }
 

--- a/integration-tests/emulated/helpers/Cargo.toml
+++ b/integration-tests/emulated/helpers/Cargo.toml
@@ -15,8 +15,8 @@ pallet-balances = { version = "29.0.0" }
 pallet-message-queue = { version = "32.0.0" }
 
 # Polkadot
-xcm = { package = "staging-xcm", version = "8.0.0" }
-pallet-xcm = { version = "8.0.1" }
+xcm = { package = "staging-xcm", version = "8.0.1" }
+pallet-xcm = { version = "8.0.2" }
 
 # Cumulus
 xcm-emulator = { version = "0.6.0" }

--- a/integration-tests/emulated/helpers/src/lib.rs
+++ b/integration-tests/emulated/helpers/src/lib.rs
@@ -21,7 +21,7 @@ pub use pallet_message_queue;
 
 // Polkadot
 pub use pallet_xcm;
-pub use xcm::prelude::{AccountId32, WeightLimit};
+pub use xcm::prelude::{AccountId32, VersionedAssets, Weight, WeightLimit};
 
 // Cumulus
 pub use asset_test_utils;
@@ -119,6 +119,60 @@ macro_rules! test_parachain_is_trusted_teleporter {
 					para_sender_balance_before = <$sender_para as $crate::Chain>::account_data_of(sender.clone()).free;
 				}
 			)+
+		}
+	};
+}
+
+#[macro_export]
+macro_rules! test_parachain_can_claim_assets {
+	( $sender_para:ty, $runtime_call:ty, $network_id:expr, $assets:expr, $amount:expr ) => {
+		$crate::paste::paste! {
+			let sender = [<$sender_para Sender>]::get();
+			let origin = <$sender_para as $crate::Chain>::RuntimeOrigin::signed(sender.clone());
+			// Receiver is the same as sender
+			let beneficiary: Location =
+				$crate::AccountId32 { network: Some($network_id), id: sender.clone().into() }.into();
+			let versioned_assets: $crate::VersionedAssets = $assets.clone().into();
+
+			<$sender_para>::execute_with(|| {
+				// Assets are trapped for whatever reason.
+				// The possible reasons for this might differ from runtime to runtime, so here we just drop them directly.
+				<$sender_para as [<$sender_para Pallet>]>::PolkadotXcm::drop_assets(
+					&beneficiary,
+					$assets.into(),
+					&XcmContext { origin: None, message_id: [0u8; 32], topic: None },
+				);
+
+				type RuntimeEvent = <$sender_para as $crate::Chain>::RuntimeEvent;
+				assert_expected_events!(
+					$sender_para,
+					vec![
+						RuntimeEvent::PolkadotXcm(
+							$crate::pallet_xcm::Event::AssetsTrapped { origin: beneficiary, assets: versioned_assets, .. }
+						) => {},
+					]
+				);
+
+				let balance_before = <$sender_para as [<$sender_para Pallet>]>::Balances::free_balance(&sender);
+
+				assert_ok!(<$sender_para as [<$sender_para Pallet>]>::PolkadotXcm::claim_assets(
+					origin.clone(),
+					bx!(versioned_assets.clone().into()),
+					bx!(beneficiary.clone().into()),
+				));
+
+				assert_expected_events!(
+					$sender_para,
+					vec![
+						RuntimeEvent::PolkadotXcm(
+							$crate::pallet_xcm::Event::AssetsClaimed { origin: beneficiary, assets: versioned_assets, .. }
+						) => {},
+					]
+				);
+
+				let balance_after = <$sender_para as [<$sender_para Pallet>]>::Balances::free_balance(&sender);
+				assert_eq!(balance_after, balance_before + $amount);
+			});
 		}
 	};
 }

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/Cargo.toml
@@ -20,9 +20,9 @@ pallet-asset-conversion = { version = "11.0.0" }
 pallet-message-queue = { version = "32.0.0" }
 
 # Polkadot
-xcm = { package = "staging-xcm", version = "8.0.0" }
+xcm = { package = "staging-xcm", version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
-pallet-xcm = { version = "8.0.1" }
+pallet-xcm = { version = "8.0.2" }
 
 # Cumulus
 parachains-common = { version = "8.0.0" }

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/claim_assets.rs
@@ -13,17 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod reserve_transfer;
-mod send;
-mod set_xcm_versions;
-mod swap;
-mod teleport;
-mod claim_assets;
+//! Tests related to claiming assets trapped during XCM execution.
 
 use crate::*;
-emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_hub!(
-	PenpalA,
-	AssetHubKusama,
-	KUSAMA_ED,
-	system_parachains_constants::kusama::fee::WeightToFee
-);
+
+use asset_hub_kusama_runtime::ExistentialDeposit;
+use integration_tests_helpers::test_parachain_can_claim_assets;
+use xcm_executor::traits::DropAssets;
+
+#[test]
+fn assets_can_be_claimed() {
+	let amount = ExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_parachain_can_claim_assets!(
+		AssetHubKusama,
+		RuntimeCall,
+		NetworkId::Kusama,
+		assets,
+		amount
+	);
+}

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/claim_assets.rs
@@ -26,11 +26,5 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_chain_can_claim_assets!(
-		AssetHubKusama,
-		RuntimeCall,
-		NetworkId::Kusama,
-		assets,
-		amount
-	);
+	test_chain_can_claim_assets!(AssetHubKusama, RuntimeCall, NetworkId::Kusama, assets, amount);
 }

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/claim_assets.rs
@@ -18,7 +18,7 @@
 use crate::*;
 
 use asset_hub_kusama_runtime::ExistentialDeposit;
-use integration_tests_helpers::test_parachain_can_claim_assets;
+use integration_tests_helpers::test_chain_can_claim_assets;
 use xcm_executor::traits::DropAssets;
 
 #[test]
@@ -26,7 +26,7 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_parachain_can_claim_assets!(
+	test_chain_can_claim_assets!(
 		AssetHubKusama,
 		RuntimeCall,
 		NetworkId::Kusama,

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
@@ -26,3 +26,15 @@ emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_
 	KUSAMA_ED,
 	system_parachains_constants::kusama::fee::WeightToFee
 );
+
+#[test]
+fn assets_can_be_claimed() {
+	use asset_hub_kusama_runtime::ExistentialDeposit;
+	use integration_tests_helpers::test_parachain_can_claim_assets;
+	use xcm_executor::traits::DropAssets;
+
+	let amount = ExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_parachain_can_claim_assets!(AssetHubKusama, RuntimeCall, NetworkId::Kusama, assets, amount);
+}

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
@@ -36,5 +36,11 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_parachain_can_claim_assets!(AssetHubKusama, RuntimeCall, NetworkId::Kusama, assets, amount);
+	test_parachain_can_claim_assets!(
+		AssetHubKusama,
+		RuntimeCall,
+		NetworkId::Kusama,
+		assets,
+		amount
+	);
 }

--- a/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-kusama/src/tests/mod.rs
@@ -13,12 +13,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod claim_assets;
 mod reserve_transfer;
 mod send;
 mod set_xcm_versions;
 mod swap;
 mod teleport;
-mod claim_assets;
 
 use crate::*;
 emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_hub!(

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/Cargo.toml
@@ -21,8 +21,8 @@ pallet-message-queue = { version = "32.0.0" }
 
 # Polkadot
 polkadot-runtime-common = { version = "8.0.1" }
-xcm = { package = "staging-xcm", version = "8.0.0" }
-pallet-xcm = { version = "8.0.1" }
+xcm = { package = "staging-xcm", version = "8.0.1" }
+pallet-xcm = { version = "8.0.2" }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/claim_assets.rs
@@ -13,17 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod reserve_transfer;
-mod send;
-mod set_xcm_versions;
-mod swap;
-mod teleport;
-mod claim_assets;
+//! Tests related to claiming assets trapped during XCM execution.
 
 use crate::*;
-emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_hub!(
-	PenpalA,
-	AssetHubKusama,
-	KUSAMA_ED,
-	system_parachains_constants::kusama::fee::WeightToFee
-);
+
+use asset_hub_polkadot_runtime::ExistentialDeposit;
+use integration_tests_helpers::test_parachain_can_claim_assets;
+use xcm_executor::traits::DropAssets;
+
+#[test]
+fn assets_can_be_claimed() {
+	let amount = ExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_parachain_can_claim_assets!(
+		AssetHubPolkadot,
+		RuntimeCall,
+		NetworkId::Polkadot,
+		assets,
+		amount
+	);
+}

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/claim_assets.rs
@@ -18,7 +18,7 @@
 use crate::*;
 
 use asset_hub_polkadot_runtime::ExistentialDeposit;
-use integration_tests_helpers::test_parachain_can_claim_assets;
+use integration_tests_helpers::test_chain_can_claim_assets;
 use xcm_executor::traits::DropAssets;
 
 #[test]
@@ -26,7 +26,7 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_parachain_can_claim_assets!(
+	test_chain_can_claim_assets!(
 		AssetHubPolkadot,
 		RuntimeCall,
 		NetworkId::Polkadot,

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
@@ -19,6 +19,7 @@ mod send;
 mod set_xcm_versions;
 mod teleport;
 mod treasury;
+mod claim_assets;
 
 use crate::*;
 emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_hub!(
@@ -27,21 +28,3 @@ emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_
 	POLKADOT_ED,
 	system_parachains_constants::polkadot::fee::WeightToFee
 );
-
-#[test]
-fn assets_can_be_claimed() {
-	use asset_hub_polkadot_runtime::ExistentialDeposit;
-	use integration_tests_helpers::test_parachain_can_claim_assets;
-	use xcm_executor::traits::DropAssets;
-
-	let amount = ExistentialDeposit::get();
-	let assets: Assets = (Parent, amount).into();
-
-	test_parachain_can_claim_assets!(
-		AssetHubPolkadot,
-		RuntimeCall,
-		NetworkId::Polkadot,
-		assets,
-		amount
-	);
-}

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
@@ -37,5 +37,11 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_parachain_can_claim_assets!(AssetHubPolkadot, RuntimeCall, NetworkId::Polkadot, assets, amount);
+	test_parachain_can_claim_assets!(
+		AssetHubPolkadot,
+		RuntimeCall,
+		NetworkId::Polkadot,
+		assets,
+		amount
+	);
 }

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
@@ -27,3 +27,15 @@ emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_
 	POLKADOT_ED,
 	system_parachains_constants::polkadot::fee::WeightToFee
 );
+
+#[test]
+fn assets_can_be_claimed() {
+	use asset_hub_polkadot_runtime::ExistentialDeposit;
+	use integration_tests_helpers::test_parachain_can_claim_assets;
+	use xcm_executor::traits::DropAssets;
+
+	let amount = ExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_parachain_can_claim_assets!(AssetHubPolkadot, RuntimeCall, NetworkId::Polkadot, assets, amount);
+}

--- a/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/assets/asset-hub-polkadot/src/tests/mod.rs
@@ -13,13 +13,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod claim_assets;
 mod fellowship_treasury;
 mod reserve_transfer;
 mod send;
 mod set_xcm_versions;
 mod teleport;
 mod treasury;
-mod claim_assets;
 
 use crate::*;
 emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_hub!(

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/Cargo.toml
@@ -17,8 +17,8 @@ pallet-assets = { version = "30.0.0" }
 pallet-message-queue = { version = "32.0.0" }
 
 # Polkadot
-xcm = { package = "staging-xcm", version = "8.0.0" }
-pallet-xcm = { version = "8.0.1" }
+xcm = { package = "staging-xcm", version = "8.0.1" }
+pallet-xcm = { version = "8.0.2" }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/claim_assets.rs
@@ -26,11 +26,5 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_chain_can_claim_assets!(
-		AssetHubKusama,
-		RuntimeCall,
-		NetworkId::Kusama,
-		assets,
-		amount
-	);
+	test_chain_can_claim_assets!(AssetHubKusama, RuntimeCall, NetworkId::Kusama, assets, amount);
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/claim_assets.rs
@@ -18,7 +18,7 @@
 use crate::*;
 
 use bridge_hub_kusama_runtime::ExistentialDeposit;
-use integration_tests_helpers::test_parachain_can_claim_assets;
+use integration_tests_helpers::test_chain_can_claim_assets;
 use xcm_executor::traits::DropAssets;
 
 #[test]
@@ -26,7 +26,7 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_parachain_can_claim_assets!(
+	test_chain_can_claim_assets!(
 		AssetHubKusama,
 		RuntimeCall,
 		NetworkId::Kusama,

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/claim_assets.rs
@@ -13,17 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod reserve_transfer;
-mod send;
-mod set_xcm_versions;
-mod swap;
-mod teleport;
-mod claim_assets;
+//! Tests related to claiming assets trapped during XCM execution.
 
 use crate::*;
-emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_hub!(
-	PenpalA,
-	AssetHubKusama,
-	KUSAMA_ED,
-	system_parachains_constants::kusama::fee::WeightToFee
-);
+
+use bridge_hub_kusama_runtime::ExistentialDeposit;
+use integration_tests_helpers::test_parachain_can_claim_assets;
+use xcm_executor::traits::DropAssets;
+
+#[test]
+fn assets_can_be_claimed() {
+	let amount = ExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_parachain_can_claim_assets!(
+		AssetHubKusama,
+		RuntimeCall,
+		NetworkId::Kusama,
+		assets,
+		amount
+	);
+}

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
@@ -106,3 +106,15 @@ pub(crate) fn assert_bridge_hub_polkadot_message_received() {
 		);
 	})
 }
+
+#[test]
+fn assets_can_be_claimed() {
+	use bridge_hub_kusama_runtime::ExistentialDeposit;
+	use integration_tests_helpers::test_parachain_can_claim_assets;
+	use xcm_executor::traits::DropAssets;
+
+	let amount = ExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_parachain_can_claim_assets!(AssetHubKusama, RuntimeCall, NetworkId::Kusama, assets, amount);
+}

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
@@ -18,6 +18,7 @@ use crate::*;
 mod asset_transfers;
 mod send_xcm;
 mod teleport;
+mod claim_assets;
 
 pub(crate) fn asset_hub_polkadot_location() -> Location {
 	Location::new(
@@ -105,22 +106,4 @@ pub(crate) fn assert_bridge_hub_polkadot_message_received() {
 			]
 		);
 	})
-}
-
-#[test]
-fn assets_can_be_claimed() {
-	use bridge_hub_kusama_runtime::ExistentialDeposit;
-	use integration_tests_helpers::test_parachain_can_claim_assets;
-	use xcm_executor::traits::DropAssets;
-
-	let amount = ExistentialDeposit::get();
-	let assets: Assets = (Parent, amount).into();
-
-	test_parachain_can_claim_assets!(
-		AssetHubKusama,
-		RuntimeCall,
-		NetworkId::Kusama,
-		assets,
-		amount
-	);
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
@@ -116,5 +116,11 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_parachain_can_claim_assets!(AssetHubKusama, RuntimeCall, NetworkId::Kusama, assets, amount);
+	test_parachain_can_claim_assets!(
+		AssetHubKusama,
+		RuntimeCall,
+		NetworkId::Kusama,
+		assets,
+		amount
+	);
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-kusama/src/tests/mod.rs
@@ -16,9 +16,9 @@
 use crate::*;
 
 mod asset_transfers;
+mod claim_assets;
 mod send_xcm;
 mod teleport;
-mod claim_assets;
 
 pub(crate) fn asset_hub_polkadot_location() -> Location {
 	Location::new(

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/Cargo.toml
@@ -17,8 +17,8 @@ pallet-assets = { version = "30.0.0" }
 pallet-message-queue = { version = "32.0.0" }
 
 # Polkadot
-xcm = { package = "staging-xcm", version = "8.0.0" }
-pallet-xcm = { version = "8.0.1" }
+xcm = { package = "staging-xcm", version = "8.0.1" }
+pallet-xcm = { version = "8.0.2" }
 xcm-executor = { package = "staging-xcm-executor", version = "8.0.1" }
 
 # Cumulus

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/claim_assets.rs
@@ -18,7 +18,7 @@
 use crate::*;
 
 use bridge_hub_polkadot_runtime::ExistentialDeposit;
-use integration_tests_helpers::test_parachain_can_claim_assets;
+use integration_tests_helpers::test_chain_can_claim_assets;
 use xcm_executor::traits::DropAssets;
 
 #[test]
@@ -26,7 +26,7 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_parachain_can_claim_assets!(
+	test_chain_can_claim_assets!(
 		AssetHubPolkadot,
 		RuntimeCall,
 		NetworkId::Polkadot,

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/claim_assets.rs
@@ -13,17 +13,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod reserve_transfer;
-mod send;
-mod set_xcm_versions;
-mod swap;
-mod teleport;
-mod claim_assets;
+//! Tests related to claiming assets trapped during XCM execution.
 
 use crate::*;
-emulated_integration_tests_common::include_penpal_create_foreign_asset_on_asset_hub!(
-	PenpalA,
-	AssetHubKusama,
-	KUSAMA_ED,
-	system_parachains_constants::kusama::fee::WeightToFee
-);
+
+use bridge_hub_polkadot_runtime::ExistentialDeposit;
+use integration_tests_helpers::test_parachain_can_claim_assets;
+use xcm_executor::traits::DropAssets;
+
+#[test]
+fn assets_can_be_claimed() {
+	let amount = ExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_parachain_can_claim_assets!(
+		AssetHubPolkadot,
+		RuntimeCall,
+		NetworkId::Polkadot,
+		assets,
+		amount
+	);
+}

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
@@ -16,9 +16,9 @@
 use crate::*;
 
 mod asset_transfers;
+mod claim_assets;
 mod send_xcm;
 mod teleport;
-mod claim_assets;
 
 pub(crate) fn asset_hub_kusama_location() -> Location {
 	Location::new(

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
@@ -18,6 +18,7 @@ use crate::*;
 mod asset_transfers;
 mod send_xcm;
 mod teleport;
+mod claim_assets;
 
 pub(crate) fn asset_hub_kusama_location() -> Location {
 	Location::new(
@@ -105,22 +106,4 @@ pub(crate) fn assert_bridge_hub_kusama_message_received() {
 			]
 		);
 	})
-}
-
-#[test]
-fn assets_can_be_claimed() {
-	use bridge_hub_polkadot_runtime::ExistentialDeposit;
-	use integration_tests_helpers::test_parachain_can_claim_assets;
-	use xcm_executor::traits::DropAssets;
-
-	let amount = ExistentialDeposit::get();
-	let assets: Assets = (Parent, amount).into();
-
-	test_parachain_can_claim_assets!(
-		AssetHubPolkadot,
-		RuntimeCall,
-		NetworkId::Polkadot,
-		assets,
-		amount
-	);
 }

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
@@ -106,3 +106,15 @@ pub(crate) fn assert_bridge_hub_kusama_message_received() {
 		);
 	})
 }
+
+#[test]
+fn assets_can_be_claimed() {
+	use bridge_hub_polkadot_runtime::ExistentialDeposit;
+	use integration_tests_helpers::test_parachain_can_claim_assets;
+	use xcm_executor::traits::DropAssets;
+
+	let amount = ExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_parachain_can_claim_assets!(AssetHubPolkadot, RuntimeCall, NetworkId::Polkadot, assets, amount);
+}

--- a/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bridges/bridge-hub-polkadot/src/tests/mod.rs
@@ -116,5 +116,11 @@ fn assets_can_be_claimed() {
 	let amount = ExistentialDeposit::get();
 	let assets: Assets = (Parent, amount).into();
 
-	test_parachain_can_claim_assets!(AssetHubPolkadot, RuntimeCall, NetworkId::Polkadot, assets, amount);
+	test_parachain_can_claim_assets!(
+		AssetHubPolkadot,
+		RuntimeCall,
+		NetworkId::Polkadot,
+		assets,
+		amount
+	);
 }

--- a/relay/kusama/Cargo.toml
+++ b/relay/kusama/Cargo.toml
@@ -81,7 +81,7 @@ pallet-treasury = { default-features = false , version = "28.0.0" }
 pallet-utility = { default-features = false , version = "29.0.0" }
 pallet-vesting = { default-features = false , version = "29.0.0" }
 pallet-whitelist = { default-features = false , version = "28.0.0" }
-pallet-xcm = { default-features = false , version = "8.0.1" }
+pallet-xcm = { default-features = false , version = "8.0.2" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 frame-election-provider-support = { default-features = false , version = "29.0.0" }
 
@@ -98,7 +98,7 @@ runtime-common = { package = "polkadot-runtime-common", default-features = false
 runtime-parachains = { package = "polkadot-runtime-parachains", default-features = false , version = "8.0.1" }
 primitives = { package = "polkadot-primitives", default-features = false , version = "8.0.1" }
 
-xcm = { package = "staging-xcm", default-features = false , version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false , version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false , version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false , version = "8.0.1" }
 

--- a/relay/kusama/src/lib.rs
+++ b/relay/kusama/src/lib.rs
@@ -2599,6 +2599,13 @@ sp_api::impl_runtime_apis! {
 						dest
 					)
 				}
+
+				fn get_asset() -> Asset {
+					Asset {
+						id: AssetId(Location::here()),
+						fun: Fungible(ExistentialDeposit::get()),
+					}
+				}
 			}
 
 			impl pallet_xcm_benchmarks::Config for Runtime {

--- a/relay/kusama/src/weights/pallet_xcm.rs
+++ b/relay/kusama/src/weights/pallet_xcm.rs
@@ -51,6 +51,9 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn claim_assets() -> Weight {
+		todo!()
+	}
 	/// Storage: `Dmp::DeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `Dmp::DeliveryFeeFactor` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `XcmPallet::SupportedVersion` (r:1 w:0)

--- a/relay/kusama/src/weights/pallet_xcm.rs
+++ b/relay/kusama/src/weights/pallet_xcm.rs
@@ -52,7 +52,10 @@ use core::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 	fn claim_assets() -> Weight {
-		todo!()
+		Weight::from_parts(35_514_000, 0)
+			.saturating_add(Weight::from_parts(0, 3488))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: `Dmp::DeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `Dmp::DeliveryFeeFactor` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/relay/polkadot/Cargo.toml
+++ b/relay/polkadot/Cargo.toml
@@ -79,7 +79,7 @@ pallet-whitelist = { default-features = false , version = "28.0.0" }
 pallet-vesting = { default-features = false , version = "29.0.0" }
 pallet-utility = { default-features = false , version = "29.0.0" }
 frame-election-provider-support = { default-features = false , version = "29.0.0" }
-pallet-xcm = { default-features = false, version = "8.0.1" }
+pallet-xcm = { default-features = false, version = "8.0.2" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 
 frame-benchmarking = { default-features = false, optional = true , version = "29.0.0" }
@@ -94,7 +94,7 @@ runtime-common = { package = "polkadot-runtime-common", default-features = false
 runtime-parachains = { package = "polkadot-runtime-parachains", default-features = false , version = "8.0.1" }
 primitives = { package = "polkadot-primitives", default-features = false , version = "8.0.1" }
 
-xcm = { package = "staging-xcm", default-features = false , version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false , version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false , version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false , version = "8.0.1" }
 

--- a/relay/polkadot/src/lib.rs
+++ b/relay/polkadot/src/lib.rs
@@ -2486,6 +2486,13 @@ sp_api::impl_runtime_apis! {
 						dest
 					)
 				}
+
+				fn get_asset() -> Asset {
+					Asset {
+						id: AssetId(Location::here()),
+						fun: Fungible(ExistentialDeposit::get()),
+					}
+				}
 			}
 
 			impl pallet_xcm_benchmarks::Config for Runtime {

--- a/relay/polkadot/src/weights/pallet_xcm.rs
+++ b/relay/polkadot/src/weights/pallet_xcm.rs
@@ -52,7 +52,10 @@ use core::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 	fn claim_assets() -> Weight {
-		todo!()
+		Weight::from_parts(35_299_000, 0)
+			.saturating_add(Weight::from_parts(0, 3488))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: `Dmp::DeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `Dmp::DeliveryFeeFactor` (`max_values`: None, `max_size`: None, mode: `Measured`)

--- a/relay/polkadot/src/weights/pallet_xcm.rs
+++ b/relay/polkadot/src/weights/pallet_xcm.rs
@@ -51,6 +51,9 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn claim_assets() -> Weight {
+		todo!()
+	}
 	/// Storage: `Dmp::DeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `Dmp::DeliveryFeeFactor` (`max_values`: None, `max_size`: None, mode: `Measured`)
 	/// Storage: `XcmPallet::SupportedVersion` (r:1 w:0)

--- a/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/Cargo.toml
@@ -67,12 +67,12 @@ sp-weights = { default-features = false, version = "28.0.0" }
 primitive-types = { version = "0.12.2", default-features = false, features = ["codec", "scale-info", "num-traits"] }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.1" }
+pallet-xcm = { default-features = false, version = "8.0.2" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 

--- a/system-parachains/asset-hubs/asset-hub-kusama/primitives/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-kusama/primitives/Cargo.toml
@@ -19,7 +19,7 @@ frame-support = { default-features = false, version = "29.0.0" }
 sp-std = { default-features = false, version = "14.0.0" }
 
 # Polkadot
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/lib.rs
@@ -1428,6 +1428,13 @@ impl_runtime_apis! {
 					});
 					Some((assets, fee_index as u32, dest, verify))
 				}
+
+				fn get_asset() -> Asset {
+					Asset {
+						id: AssetId(Location::parent()),
+						fun: Fungible(ExistentialDeposit::get()),
+					}
+				}
 			}
 
 			impl pallet_xcm_benchmarks::Config for Runtime {

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/weights/pallet_xcm.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/weights/pallet_xcm.rs
@@ -47,6 +47,9 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn claim_assets() -> Weight {
+		todo!()
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/system-parachains/asset-hubs/asset-hub-kusama/src/weights/pallet_xcm.rs
+++ b/system-parachains/asset-hubs/asset-hub-kusama/src/weights/pallet_xcm.rs
@@ -48,7 +48,10 @@ use core::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 	fn claim_assets() -> Weight {
-		todo!()
+		Weight::from_parts(39_122_000, 0)
+			.saturating_add(Weight::from_parts(0, 3625))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)

--- a/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/Cargo.toml
@@ -62,12 +62,12 @@ sp-version = { default-features = false, version = "30.0.0" }
 sp-weights = { default-features = false, version = "28.0.0" }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.1" }
+pallet-xcm = { default-features = false, version = "8.0.2" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 

--- a/system-parachains/asset-hubs/asset-hub-polkadot/primitives/Cargo.toml
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/primitives/Cargo.toml
@@ -19,7 +19,7 @@ frame-support = { default-features = false, version = "29.0.0" }
 sp-std = { default-features = false, version = "14.0.0" }
 
 # Polkadot
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 
 [features]
 default = [ "std" ]

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/lib.rs
@@ -1298,6 +1298,13 @@ impl_runtime_apis! {
 					});
 					Some((assets, fee_index as u32, dest, verify))
 				}
+
+				fn get_asset() -> Asset {
+					Asset {
+						id: AssetId(Location::parent()),
+						fun: Fungible(ExistentialDeposit::get()),
+					}
+				}
 			}
 
 			impl pallet_xcm_benchmarks::Config for Runtime {

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_xcm.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_xcm.rs
@@ -48,7 +48,10 @@ use core::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 	fn claim_assets() -> Weight {
-		todo!()
+		Weight::from_parts(38_075_000, 0)
+			.saturating_add(Weight::from_parts(0, 3625))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)

--- a/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_xcm.rs
+++ b/system-parachains/asset-hubs/asset-hub-polkadot/src/weights/pallet_xcm.rs
@@ -47,6 +47,9 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn claim_assets() -> Weight {
+		todo!()
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/Cargo.toml
@@ -60,12 +60,12 @@ sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.1" }
+pallet-xcm = { default-features = false, version = "8.0.2" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/lib.rs
@@ -865,6 +865,13 @@ impl_runtime_apis! {
 						dest
 					)
 				}
+
+				fn get_asset() -> Asset {
+					Asset {
+						id: AssetId(Location::parent()),
+						fun: Fungible(ExistentialDeposit::get()),
+					}
+				}
 			}
 
 			impl pallet_xcm_benchmarks::Config for Runtime {

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/weights/pallet_xcm.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/weights/pallet_xcm.rs
@@ -48,7 +48,10 @@ use core::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 	fn claim_assets() -> Weight {
-		todo!()
+		Weight::from_parts(34_674_000, 0)
+			.saturating_add(Weight::from_parts(0, 3555))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)

--- a/system-parachains/bridge-hubs/bridge-hub-kusama/src/weights/pallet_xcm.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-kusama/src/weights/pallet_xcm.rs
@@ -47,6 +47,9 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn claim_assets() -> Weight {
+		todo!()
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/Cargo.toml
@@ -60,12 +60,12 @@ sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.1" }
+pallet-xcm = { default-features = false, version = "8.0.2" }
 pallet-xcm-benchmarks = { default-features = false, optional = true , version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/lib.rs
@@ -866,6 +866,13 @@ impl_runtime_apis! {
 						dest
 					)
 				}
+
+				fn get_asset() -> Asset {
+					Asset {
+						id: AssetId(Location::parent()),
+						fun: Fungible(ExistentialDeposit::get()),
+					}
+				}
 			}
 
 			impl pallet_xcm_benchmarks::Config for Runtime {

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_xcm.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_xcm.rs
@@ -48,7 +48,10 @@ use core::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 	fn claim_assets() -> Weight {
-		todo!()
+		Weight::from_parts(35_411_000, 0)
+			.saturating_add(Weight::from_parts(0, 3555))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)

--- a/system-parachains/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_xcm.rs
+++ b/system-parachains/bridge-hubs/bridge-hub-polkadot/src/weights/pallet_xcm.rs
@@ -47,6 +47,9 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn claim_assets() -> Weight {
+		todo!()
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/system-parachains/collectives/collectives-polkadot/Cargo.toml
+++ b/system-parachains/collectives/collectives-polkadot/Cargo.toml
@@ -59,12 +59,12 @@ sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 
 # Polkadot
-pallet-xcm = { default-features = false, version = "8.0.1" }
+pallet-xcm = { default-features = false, version = "8.0.2" }
 polkadot-core-primitives = { default-features = false, version = "8.0.0" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }
 polkadot-runtime-constants = { path = "../../../relay/polkadot/constants", default-features = false}
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 

--- a/system-parachains/collectives/collectives-polkadot/src/lib.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/lib.rs
@@ -1021,6 +1021,13 @@ impl_runtime_apis! {
 						dest
 					)
 				}
+
+				fn get_asset() -> Asset {
+					Asset {
+						id: AssetId(Location::parent()),
+						fun: Fungible(ExistentialDeposit::get()),
+					}
+				}
 			}
 
 			let whitelist: Vec<TrackedStorageKey> = vec![

--- a/system-parachains/collectives/collectives-polkadot/src/weights/pallet_xcm.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/weights/pallet_xcm.rs
@@ -48,7 +48,10 @@ use core::marker::PhantomData;
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
 	fn claim_assets() -> Weight {
-		todo!()
+		Weight::from_parts(36_978_000, 0)
+			.saturating_add(Weight::from_parts(0, 3625))
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(1))
 	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)

--- a/system-parachains/collectives/collectives-polkadot/src/weights/pallet_xcm.rs
+++ b/system-parachains/collectives/collectives-polkadot/src/weights/pallet_xcm.rs
@@ -47,6 +47,9 @@ use core::marker::PhantomData;
 /// Weight functions for `pallet_xcm`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> pallet_xcm::WeightInfo for WeightInfo<T> {
+	fn claim_assets() -> Weight {
+		todo!()
+	}
 	/// Storage: `ParachainSystem::UpwardDeliveryFeeFactor` (r:1 w:0)
 	/// Proof: `ParachainSystem::UpwardDeliveryFeeFactor` (`max_values`: Some(1), `max_size`: None, mode: `Measured`)
 	/// Storage: `PolkadotXcm::SupportedVersion` (r:1 w:0)

--- a/system-parachains/encointer/Cargo.toml
+++ b/system-parachains/encointer/Cargo.toml
@@ -71,10 +71,10 @@ sp-version = { default-features = false, version = "30.0.0" }
 sp-genesis-builder = { default-features = false, version = "0.8.0" }
 
 # Polkadot dependencies
-pallet-xcm = { default-features = false, version = "8.0.1" }
+pallet-xcm = { default-features = false, version = "8.0.2" }
 polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
 polkadot-runtime-common = { default-features = false, version = "8.0.1" }
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 

--- a/system-parachains/gluttons/glutton-kusama/Cargo.toml
+++ b/system-parachains/gluttons/glutton-kusama/Cargo.toml
@@ -37,7 +37,7 @@ sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 
 # Polkadot
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.1" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.1" }
 


### PR DESCRIPTION
Added changes for the polkadot-sdk 1.7.0 backport containing the `claim_assets` extrinsic.
Also, added tests for it for all major runtimes.

## TODO
- [ ] Add tests for the extrinsic
  - [x] To system parachains
  - [ ] To the relays
