### PR TITLE
Update hardcoded weights in coretime chain runtimes

### DIFF
--- a/system-parachains/coretime/coretime-kusama/src/coretime.rs
+++ b/system-parachains/coretime/coretime-kusama/src/coretime.rs
@@ -137,10 +137,10 @@ impl CoretimeInterface for CoretimeAllocator {
 		let request_core_count_call = RelayRuntimePallets::Coretime(RequestCoreCount(count));
 
 		// Weight for `request_core_count` from Kusama runtime benchmarks:
-		// `ref_time` = 7889000 + (3 * 25000000) + (1 * 100000000) = 182889000
-		// `proof_size` = 1636
-		// Add 5% to each component and round to 2 significant figures.
-		let call_weight = Weight::from_parts(190_000_000, 1700);
+		// `ref_time`, `proof_size`, reads, writes
+		// 9_670_000, 1640, 3, 1
+		// Add 10% to each component and round to 3 significant figures.
+		let call_weight = Weight::from_parts(203_000_000, 1800);
 
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
@@ -173,13 +173,10 @@ impl CoretimeInterface for CoretimeAllocator {
 			RelayRuntimePallets::Coretime(RequestRevenueInfoAt(when));
 
 		// Weight for `request_revenue_at` from Kusama runtime benchmarks:
-		// `ref_time` = 37_637_000 + (3 * 25000000) + (6 * 100000000) = 712637000
-		// `proof_size` = 6428
-		// Add 5% to each component and round to 2 significant figures.
-		//
-		// This benchmark has been transplanted from a testnet and not rerun, so adding a healthy
-		// buffer. TODO refine when benchmarks are run: https://github.com/polkadot-fellows/runtimes/issues/404
-		let call_weight = Weight::from_parts(1_000_000_000, 20_000);
+		// `ref_time`, `proof_size`, reads, writes
+		// 94_091_000, 6384, 7, 5
+		// Add 10% to each component and round to 3 significant figures.
+		let call_weight = Weight::from_parts(846_000_000, 7020);
 
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
@@ -225,10 +222,10 @@ impl CoretimeInterface for CoretimeAllocator {
 		use crate::coretime::CoretimeProviderCalls::AssignCore;
 
 		// Weight for `assign_core` from Kusama runtime benchmarks:
-		// `ref_time` = 10177115 + (1 * 25000000) + (2 * 100000000) + (80 * 13932) = 236291675
-		// `proof_size` = 3612
-		// Add 5% to each component and round to 2 significant figures.
-		let call_weight = Weight::from_parts(248_000_000, 3800);
+		// `ref_time`, `proof_size`, reads, writes
+		// 12_042_907 + 80 * 13_919, 3545, 1, 2
+		// Add 10% to each component and round to 3 significant figures.
+		let call_weight = Weight::from_parts(262_000_000, 3900);
 
 		// The relay chain currently only allows `assign_core` to be called with a complete mask
 		// and only ever with increasing `begin`. The assignments must be truncated to avoid

--- a/system-parachains/coretime/coretime-kusama/src/coretime.rs
+++ b/system-parachains/coretime/coretime-kusama/src/coretime.rs
@@ -25,6 +25,7 @@ use frame_support::{
 		tokens::{Fortitude, Preservation},
 		DefensiveResult, OnUnbalanced,
 	},
+	weights::constants::{WEIGHT_PROOF_SIZE_PER_KB, WEIGHT_REF_TIME_PER_MICROS},
 };
 use frame_system::Pallet as System;
 use kusama_runtime_constants::{system_parachain::coretime, time::DAYS as RELAY_DAYS};
@@ -139,8 +140,9 @@ impl CoretimeInterface for CoretimeAllocator {
 		// Weight for `request_core_count` from Kusama runtime benchmarks:
 		// `ref_time`, `proof_size`, reads, writes
 		// 9_670_000, 1640, 3, 1
-		// Add 10% to each component and round to 3 significant figures.
-		let call_weight = Weight::from_parts(203_000_000, 1800);
+		// Add 30% to each component with a healthy round up.
+		let call_weight =
+			Weight::from_parts(250 * WEIGHT_REF_TIME_PER_MICROS, 3 * WEIGHT_PROOF_SIZE_PER_KB);
 
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
@@ -175,8 +177,9 @@ impl CoretimeInterface for CoretimeAllocator {
 		// Weight for `request_revenue_at` from Kusama runtime benchmarks:
 		// `ref_time`, `proof_size`, reads, writes
 		// 94_091_000, 6384, 7, 5
-		// Add 10% to each component and round to 3 significant figures.
-		let call_weight = Weight::from_parts(846_000_000, 7020);
+		// Add 30% to each component with a healthy round up.
+		let call_weight =
+			Weight::from_parts(1000 * WEIGHT_REF_TIME_PER_MICROS, 9 * WEIGHT_PROOF_SIZE_PER_KB);
 
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
@@ -224,8 +227,9 @@ impl CoretimeInterface for CoretimeAllocator {
 		// Weight for `assign_core` from Kusama runtime benchmarks:
 		// `ref_time`, `proof_size`, reads, writes
 		// 12_042_907 + 80 * 13_919, 3545, 1, 2
-		// Add 10% to each component and round to 3 significant figures.
-		let call_weight = Weight::from_parts(262_000_000, 3900);
+		// Add 30% to each component with a healthy round up.
+		let call_weight =
+			Weight::from_parts(350 * WEIGHT_REF_TIME_PER_MICROS, 5 * WEIGHT_PROOF_SIZE_PER_KB);
 
 		// The relay chain currently only allows `assign_core` to be called with a complete mask
 		// and only ever with increasing `begin`. The assignments must be truncated to avoid

--- a/system-parachains/coretime/coretime-polkadot/src/coretime.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/coretime.rs
@@ -137,11 +137,10 @@ impl CoretimeInterface for CoretimeAllocator {
 		let request_core_count_call = RelayRuntimePallets::Coretime(RequestCoreCount(count));
 
 		// Weight for `request_core_count` from Polkadot runtime benchmarks:
-		// `ref_time` = 7889000 + (3 * 25000000) + (1 * 100000000) = 182889000
-		// `proof_size` = 1636
-		// Add 5% to each component and round to 2 significant figures.
-		// TODO check when benchmarks are rerun
-		let call_weight = Weight::from_parts(190_000_000, 1700);
+		// `ref_time`, `proof_size`, reads, writes
+		// 9_660_000, 1640, 3, 1
+		// Use overestimates for reads and writes, add 10% and round to 3sf.
+		let call_weight = Weight::from_parts(203_000_000, 1800);
 
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
@@ -174,13 +173,10 @@ impl CoretimeInterface for CoretimeAllocator {
 			RelayRuntimePallets::Coretime(RequestRevenueInfoAt(when));
 
 		// Weight for `request_revenue_at` from Polkadot runtime benchmarks:
-		// `ref_time` = 37_637_000 + (3 * 25000000) + (6 * 100000000) = 712637000
-		// `proof_size` = 6428
-		// Add 5% to each component and round to 2 significant figures.
-		//
-		// These weights have been transplanted from another network and not rerun, so a healthy
-		// buffer is included. TODO refine when benchmarks are run.
-		let call_weight = Weight::from_parts(1_000_000_000, 20_000);
+		// `ref_time`, `proof_size`, reads, writes
+		// 93_731_000, 6313, 7, 5
+		// Use overestimates for reads and writes, add 10% and round to 3sf.
+		let call_weight = Weight::from_parts(846_000_000, 6940);
 
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
@@ -226,11 +222,10 @@ impl CoretimeInterface for CoretimeAllocator {
 		use crate::coretime::CoretimeProviderCalls::AssignCore;
 
 		// Weight for `assign_core` from Polkadot runtime benchmarks:
-		// `ref_time` = 10177115 + (1 * 25000000) + (2 * 100000000) + (80 * 13932) = 236291675
-		// `proof_size` = 3612
-		// Add 5% to each component and round to 2 significant figures.
-		// TODO check when benchmarks are rerun
-		let call_weight = Weight::from_parts(248_000_000, 3800);
+		// `ref_time`, `proof_size`, reads, writes
+		// 12_201_135 + 80 * 13_556, 3579, 1, 2
+		// Use overestimates for reads and writes, add 10% and round to 3sf.
+		let call_weight = Weight::from_parts(262_000_000, 3940);
 
 		// The relay chain currently only allows `assign_core` to be called with a complete mask
 		// and only ever with increasing `begin`. The assignments must be truncated to avoid

--- a/system-parachains/coretime/coretime-polkadot/src/coretime.rs
+++ b/system-parachains/coretime/coretime-polkadot/src/coretime.rs
@@ -25,6 +25,7 @@ use frame_support::{
 		tokens::{Fortitude, Preservation},
 		DefensiveResult, OnUnbalanced,
 	},
+	weights::constants::{WEIGHT_PROOF_SIZE_PER_KB, WEIGHT_REF_TIME_PER_MICROS},
 };
 use frame_system::Pallet as System;
 use pallet_broker::{CoreAssignment, CoreIndex, CoretimeInterface, PartsOf57600, RCBlockNumberOf};
@@ -139,8 +140,10 @@ impl CoretimeInterface for CoretimeAllocator {
 		// Weight for `request_core_count` from Polkadot runtime benchmarks:
 		// `ref_time`, `proof_size`, reads, writes
 		// 9_660_000, 1640, 3, 1
-		// Use overestimates for reads and writes, add 10% and round to 3sf.
-		let call_weight = Weight::from_parts(203_000_000, 1800);
+		// Use overestimates for reads and writes, add 30% to each component with a healthy round
+		// up.
+		let call_weight =
+			Weight::from_parts(250 * WEIGHT_REF_TIME_PER_MICROS, 3 * WEIGHT_PROOF_SIZE_PER_KB);
 
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
@@ -175,8 +178,10 @@ impl CoretimeInterface for CoretimeAllocator {
 		// Weight for `request_revenue_at` from Polkadot runtime benchmarks:
 		// `ref_time`, `proof_size`, reads, writes
 		// 93_731_000, 6313, 7, 5
-		// Use overestimates for reads and writes, add 10% and round to 3sf.
-		let call_weight = Weight::from_parts(846_000_000, 6940);
+		// Use overestimates for reads and writes, add 30% to each component with a healthy round
+		// up.
+		let call_weight =
+			Weight::from_parts(1000 * WEIGHT_REF_TIME_PER_MICROS, 9 * WEIGHT_PROOF_SIZE_PER_KB);
 
 		let message = Xcm(vec![
 			Instruction::UnpaidExecution {
@@ -224,8 +229,10 @@ impl CoretimeInterface for CoretimeAllocator {
 		// Weight for `assign_core` from Polkadot runtime benchmarks:
 		// `ref_time`, `proof_size`, reads, writes
 		// 12_201_135 + 80 * 13_556, 3579, 1, 2
-		// Use overestimates for reads and writes, add 10% and round to 3sf.
-		let call_weight = Weight::from_parts(262_000_000, 3940);
+		// Use overestimates for reads and writes, add 30% to each component with a healthy round
+		// up.
+		let call_weight =
+			Weight::from_parts(350 * WEIGHT_REF_TIME_PER_MICROS, 5 * WEIGHT_PROOF_SIZE_PER_KB);
 
 		// The relay chain currently only allows `assign_core` to be called with a complete mask
 		// and only ever with increasing `begin`. The assignments must be truncated to avoid


### PR DESCRIPTION
The new `request_revenue_info` extrinisic was added to Kusama and Polkadot and benchmarked for the first time for both.

This PR increases the buffers of the regularly sent XCMs between the Coretime Chain and Relay on both networks. The buffers use an overestimate for the read/write `ref_time` and add an additional 30% buffer, rounding up. This gives us freedom to update either chain independently of the other as long as the new benchmarks are within these bounds, while minimising weight overuse for the regularly sent XCMs.

- [x] TODO double check relay hardcoded weights against pallet-broker benchmarks

Weights check Polkadot relay:
```
	// 1.1 * max(Reserve, SetLease, NotifyCoreCount, NotifyRevenue, SwapLeases)
	// max(170, 207, 112, 113, 147) * WEIGHT_REF_TIME_PER_MICROS
	// max(15, 2, 0, 0, 2) * WEIGHT_PROOF_SIZE_PER_KB
	pub MaxXcmTransactWeight: Weight = Weight::from_parts(
		250 * WEIGHT_REF_TIME_PER_MICROS,
		20 * WEIGHT_PROOF_SIZE_PER_KB
	);
```

This leaves about a 30% buffer for the one-shot (migration) weights and ~70-100% for the regularly sent ones

Weights check Kusama relay:
```
	// 1.1 * max(Reserve, SetLease, NotifyCoreCount, NotifyRevenue, SwapLeases)
	// max(169, 207, 113, 113, 147) * WEIGHT_REF_TIME_PER_MICROS
	// max(15, 2, 0, 0, 2) * WEIGHT_PROOF_SIZE_PER_KB
	pub MaxXcmTransactWeight: Weight = Weight::from_parts(
		250 * WEIGHT_REF_TIME_PER_MICROS,
		20 * WEIGHT_PROOF_SIZE_PER_KB
	);
```

This is about the same