### PR TITLE
System parachain XCM config for Bulletin

### DIFF
--- a/.github/workflows/integration-tests-matrix.json
+++ b/.github/workflows/integration-tests-matrix.json
@@ -8,6 +8,10 @@
     "package": "asset-hub-polkadot-integration-tests"
   },
   {
+    "name": "bulletin-polkadot",
+    "package": "bulletin-polkadot-integration-tests"
+  },
+  {
     "name": "bridge-hub-kusama",
     "package": "bridge-hub-kusama-integration-tests"
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2786,6 +2786,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "bulletin-polkadot-emulated-chain"
+version = "1.0.0"
+dependencies = [
+ "bulletin-polkadot-runtime",
+ "cumulus-primitives-core",
+ "emulated-integration-tests-common",
+ "frame-support",
+ "parachains-common",
+ "sp-core 39.0.0",
+]
+
+[[package]]
+name = "bulletin-polkadot-integration-tests"
+version = "1.0.0"
+dependencies = [
+ "asset-test-utils",
+ "bulletin-polkadot-runtime",
+ "cumulus-pallet-parachain-system",
+ "emulated-integration-tests-common",
+ "frame-support",
+ "integration-tests-helpers",
+ "pallet-balances",
+ "pallet-message-queue",
+ "pallet-xcm",
+ "parachains-common",
+ "parity-scale-codec",
+ "polkadot-runtime",
+ "polkadot-runtime-common",
+ "polkadot-runtime-constants",
+ "polkadot-system-emulated-network",
+ "sp-runtime 45.0.0",
+ "staging-xcm",
+ "staging-xcm-executor",
+ "xcm-runtime-apis",
+]
+
+[[package]]
 name = "bulletin-polkadot-runtime"
 version = "1.0.0"
 dependencies = [
@@ -12380,6 +12417,7 @@ version = "1.0.0"
 dependencies = [
  "asset-hub-polkadot-emulated-chain",
  "bridge-hub-polkadot-emulated-chain",
+ "bulletin-polkadot-emulated-chain",
  "collectives-polkadot-emulated-chain",
  "coretime-polkadot-emulated-chain",
  "emulated-integration-tests-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ bp-relayers = { version = "0.25.0", default-features = false }
 bp-runtime = { version = "0.25.0", default-features = false }
 bp-xcm-bridge-hub = { version = "0.11.0", default-features = false }
 bp-xcm-bridge-hub-router = { version = "0.22.0", default-features = false }
+bulletin-polkadot-emulated-chain = { path = "integration-tests/emulated/chains/parachains/bulletin/bulletin-polkadot" }
+bulletin-polkadot-runtime = { path = "system-parachains/bulletin/bulletin-polkadot" }
 bridge-hub-common = { version = "0.18.0", default-features = false }
 bridge-hub-kusama-emulated-chain = { path = "integration-tests/emulated/chains/parachains/bridges/bridge-hub-kusama" }
 bridge-hub-kusama-runtime = { path = "system-parachains/bridge-hubs/bridge-hub-kusama" }
@@ -293,6 +295,7 @@ members = [
 	"chain-spec-generator",
 	"integration-tests/emulated/chains/parachains/assets/asset-hub-kusama",
 	"integration-tests/emulated/chains/parachains/assets/asset-hub-polkadot",
+	"integration-tests/emulated/chains/parachains/bulletin/bulletin-polkadot",
 	"integration-tests/emulated/chains/parachains/bridges/bridge-hub-kusama",
 	"integration-tests/emulated/chains/parachains/bridges/bridge-hub-polkadot",
 	"integration-tests/emulated/chains/parachains/collectives/collectives-polkadot",
@@ -310,6 +313,7 @@ members = [
 	"integration-tests/emulated/networks/polkadot-system",
 	"integration-tests/emulated/tests/assets/asset-hub-kusama",
 	"integration-tests/emulated/tests/assets/asset-hub-polkadot",
+	"integration-tests/emulated/tests/bulletin/bulletin-polkadot",
 	"integration-tests/emulated/tests/bridges/bridge-hub-kusama",
 	"integration-tests/emulated/tests/bridges/bridge-hub-polkadot",
 	"integration-tests/emulated/tests/collectives/collectives-polkadot",

--- a/integration-tests/emulated/networks/polkadot-system/Cargo.toml
+++ b/integration-tests/emulated/networks/polkadot-system/Cargo.toml
@@ -14,6 +14,7 @@ emulated-integration-tests-common = { workspace = true }
 
 # Runtimes
 asset-hub-polkadot-emulated-chain = { workspace = true }
+bulletin-polkadot-emulated-chain = { workspace = true }
 bridge-hub-polkadot-emulated-chain = { workspace = true }
 collectives-polkadot-emulated-chain = { workspace = true }
 coretime-polkadot-emulated-chain = { workspace = true }
@@ -24,6 +25,7 @@ people-polkadot-emulated-chain = { workspace = true }
 [features]
 runtime-benchmarks = [
 	"asset-hub-polkadot-emulated-chain/runtime-benchmarks",
+	"bulletin-polkadot-emulated-chain/runtime-benchmarks",
 	"bridge-hub-polkadot-emulated-chain/runtime-benchmarks",
 	"collectives-polkadot-emulated-chain/runtime-benchmarks",
 	"coretime-polkadot-emulated-chain/runtime-benchmarks",

--- a/integration-tests/emulated/networks/polkadot-system/src/lib.rs
+++ b/integration-tests/emulated/networks/polkadot-system/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub use asset_hub_polkadot_emulated_chain;
 pub use bridge_hub_polkadot_emulated_chain;
+pub use bulletin_polkadot_emulated_chain;
 pub use collectives_polkadot_emulated_chain;
 pub use coretime_polkadot_emulated_chain;
 pub use penpal_emulated_chain;
@@ -23,6 +24,7 @@ pub use polkadot_emulated_chain;
 
 use asset_hub_polkadot_emulated_chain::AssetHubPolkadot;
 use bridge_hub_polkadot_emulated_chain::BridgeHubPolkadot;
+use bulletin_polkadot_emulated_chain::BulletinPolkadot;
 use collectives_polkadot_emulated_chain::CollectivesPolkadot;
 use coretime_polkadot_emulated_chain::CoretimePolkadot;
 use penpal_emulated_chain::{PenpalA, PenpalB};
@@ -40,6 +42,7 @@ decl_test_networks! {
 		relay_chain = Polkadot,
 		parachains = vec![
 			AssetHubPolkadot,
+			BulletinPolkadot,
 			BridgeHubPolkadot,
 			CollectivesPolkadot,
 			CoretimePolkadot,
@@ -54,6 +57,7 @@ decl_test_networks! {
 decl_test_sender_receiver_accounts_parameter_types! {
 	PolkadotRelay { sender: ALICE, receiver: BOB },
 	AssetHubPolkadotPara { sender: ALICE, receiver: BOB },
+	BulletinPolkadotPara { sender: ALICE, receiver: BOB },
 	BridgeHubPolkadotPara { sender: ALICE, receiver: BOB },
 	CollectivesPolkadotPara { sender: ALICE, receiver: BOB },
 	CoretimePolkadotPara { sender: ALICE, receiver: BOB },

--- a/integration-tests/emulated/tests/bulletin/bulletin-polkadot/Cargo.toml
+++ b/integration-tests/emulated/tests/bulletin/bulletin-polkadot/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "bulletin-polkadot-integration-tests"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license = "Apache-2.0"
+description = "Bulletin Polkadot runtime integration tests with xcm-emulator"
+publish = false
+
+[dependencies]
+codec = { workspace = true, default-features = true }
+
+# Substrate
+sp-runtime = { workspace = true, default-features = true }
+frame-support = { workspace = true, default-features = true }
+pallet-balances = { workspace = true, default-features = true }
+pallet-message-queue = { workspace = true, default-features = true }
+
+# Polkadot
+polkadot-runtime-common = { workspace = true, default-features = true }
+pallet-xcm = { workspace = true, default-features = true }
+xcm = { workspace = true, default-features = true }
+xcm-executor = { workspace = true }
+xcm-runtime-apis = { workspace = true, default-features = true }
+
+# Cumulus
+parachains-common = { workspace = true, default-features = true }
+emulated-integration-tests-common = { workspace = true }
+asset-test-utils = { workspace = true }
+cumulus-pallet-parachain-system = { workspace = true, default-features = true }
+
+# Local
+polkadot-runtime-constants = { workspace = true, default-features = true }
+polkadot-runtime = { workspace = true }
+integration-tests-helpers = { workspace = true }
+bulletin-polkadot-runtime = { workspace = true }
+polkadot-system-emulated-network = { workspace = true }
+
+[features]
+runtime-benchmarks = [
+	"bulletin-polkadot-runtime/runtime-benchmarks",
+	"cumulus-pallet-parachain-system/runtime-benchmarks",
+	"frame-support/runtime-benchmarks",
+	"integration-tests-helpers/runtime-benchmarks",
+	"pallet-balances/runtime-benchmarks",
+	"pallet-message-queue/runtime-benchmarks",
+	"pallet-xcm/runtime-benchmarks",
+	"parachains-common/runtime-benchmarks",
+	"polkadot-runtime-common/runtime-benchmarks",
+	"polkadot-runtime-constants/runtime-benchmarks",
+	"polkadot-runtime/runtime-benchmarks",
+	"polkadot-system-emulated-network/runtime-benchmarks",
+	"sp-runtime/runtime-benchmarks",
+	"xcm-executor/runtime-benchmarks",
+	"xcm-runtime-apis/runtime-benchmarks",
+	"xcm/runtime-benchmarks",
+]

--- a/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/lib.rs
+++ b/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/lib.rs
@@ -1,0 +1,41 @@
+// Copyright (C) Parity Technologies and the various Polkadot contributors, see Contributions.md
+// for a list of specific contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Substrate
+pub use frame_support::{assert_ok, traits::fungibles::Inspect};
+
+// Polkadot
+pub use xcm::prelude::*;
+
+// Cumulus
+pub use bulletin_polkadot_runtime::ExistentialDeposit as BulletinPolkadotExistentialDeposit;
+pub use emulated_integration_tests_common::xcm_emulator::{Chain, TestExt};
+pub use parachains_common::{AccountId, Balance};
+pub use polkadot_system_emulated_network::{
+	asset_hub_polkadot_emulated_chain::genesis::ED as ASSET_HUB_POLKADOT_ED,
+	bulletin_polkadot_emulated_chain::{
+		self, bulletin_polkadot_runtime, genesis::ED as BULLETIN_POLKADOT_ED,
+		BulletinPolkadotParaPallet as BulletinPolkadotPallet,
+	},
+	penpal_emulated_chain::PenpalAssetOwner,
+	polkadot_emulated_chain::genesis::ED as POLKADOT_ED,
+	AssetHubPolkadotPara as AssetHubPolkadot, BridgeHubPolkadotPara as BridgeHubPolkadot,
+	BulletinPolkadotPara as BulletinPolkadot, CollectivesPolkadotPara as CollectivesPolkadot,
+	PenpalAPara as PenpalA, PeoplePolkadotPara as PeoplePolkadot, PolkadotRelay as Polkadot,
+};
+
+#[cfg(test)]
+mod tests;

--- a/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/tests/aliases.rs
+++ b/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/tests/aliases.rs
@@ -1,0 +1,275 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests related to XCM aliasing.
+
+use crate::*;
+use bulletin_polkadot_runtime::xcm_config::XcmConfig;
+use emulated_integration_tests_common::{macros::AccountId, test_cross_chain_alias};
+use frame_support::traits::ContainsPair;
+use xcm::latest::Junctions::*;
+
+const ALLOWED: bool = true;
+const DENIED: bool = false;
+
+const TELEPORT_FEES: bool = true;
+const RESERVE_TRANSFER_FEES: bool = false;
+
+#[test]
+fn account_on_sibling_syschain_aliases_into_same_local_account() {
+	// origin and target are the same account on different chains
+	let origin: AccountId = [1; 32].into();
+	let target = origin.clone();
+	let fees = POLKADOT_ED * 10;
+
+	PenpalA::mint_foreign_asset(
+		<PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
+		Location::parent(),
+		origin.clone(),
+		fees * 10,
+	);
+
+	// Aliasing same account on different chains
+	test_cross_chain_alias!(
+		vec![
+			// between AH and Bulletin: allowed
+			(AssetHubPolkadot, BulletinPolkadot, TELEPORT_FEES, ALLOWED),
+			// between BH and Bulletin: allowed
+			(BridgeHubPolkadot, BulletinPolkadot, TELEPORT_FEES, ALLOWED),
+			// between Collectives and Bulletin: allowed
+			(CollectivesPolkadot, BulletinPolkadot, TELEPORT_FEES, ALLOWED),
+			// between People and Bulletin: allowed
+			(PeoplePolkadot, BulletinPolkadot, TELEPORT_FEES, ALLOWED),
+			// between Penpal and Bulletin: denied
+			(PenpalA, BulletinPolkadot, RESERVE_TRANSFER_FEES, DENIED)
+		],
+		origin,
+		target,
+		fees
+	);
+}
+
+#[test]
+fn account_on_sibling_chain_cannot_alias_into_different_local_account() {
+	// origin and target are different accounts on different chains
+	let origin: AccountId = [1; 32].into();
+	let target: AccountId = [2; 32].into();
+	let fees = POLKADOT_ED * 10;
+
+	PenpalA::mint_foreign_asset(
+		<PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get()),
+		Location::parent(),
+		origin.clone(),
+		fees * 10,
+	);
+
+	// Aliasing different account on different chains
+	test_cross_chain_alias!(
+		vec![
+			// between AH and Bulletin: denied
+			(AssetHubPolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between BH and Bulletin: denied
+			(BridgeHubPolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between Collectives and Bulletin: denied
+			(CollectivesPolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between People and Bulletin: denied
+			(PeoplePolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between Penpal and Bulletin: denied
+			(PenpalA, BulletinPolkadot, RESERVE_TRANSFER_FEES, DENIED)
+		],
+		origin,
+		target,
+		fees
+	);
+}
+
+#[test]
+fn aliasing_child_locations() {
+	BulletinPolkadot::execute_with(|| {
+		// Allows aliasing descendant of origin.
+		let origin = Location::new(1, X1([PalletInstance(8)].into()));
+		let target = Location::new(1, X2([PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(8)].into()));
+		let target = Location::new(
+			1,
+			X2([Parachain(8), AccountId32Junction { network: None, id: [1u8; 32] }].into()),
+		);
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(8)].into()));
+		let target =
+			Location::new(1, X3([Parachain(8), PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+
+		// Does not allow if not descendant.
+		let origin = Location::new(1, X1([PalletInstance(8)].into()));
+		let target = Location::new(0, X2([PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(8)].into()));
+		let target = Location::new(
+			0,
+			X2([Parachain(8), AccountId32Junction { network: None, id: [1u8; 32] }].into()),
+		);
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(8)].into()));
+		let target =
+			Location::new(0, X1([AccountId32Junction { network: None, id: [1u8; 32] }].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin =
+			Location::new(1, X1([AccountId32Junction { network: None, id: [1u8; 32] }].into()));
+		let target =
+			Location::new(0, X1([AccountId32Junction { network: None, id: [1u8; 32] }].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+	});
+}
+
+#[test]
+fn asset_hub_root_aliases_anything() {
+	BulletinPolkadot::execute_with(|| {
+		// Allows AH root to alias anything.
+		let origin = Location::new(1, X1([Parachain(1000)].into()));
+
+		let target = Location::new(1, X1([Parachain(2000)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target =
+			Location::new(1, X1([AccountId32Junction { network: None, id: [1u8; 32] }].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(
+			1,
+			X2([Parachain(8), AccountId32Junction { network: None, id: [1u8; 32] }].into()),
+		);
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target =
+			Location::new(1, X3([Parachain(42), PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(2, X1([GlobalConsensus(Ethereum { chain_id: 1 })].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(2, X2([GlobalConsensus(Kusama), Parachain(1000)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(0, X2([PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+
+		// Other AH locations cannot alias anything.
+		let origin = Location::new(1, X2([Parachain(1000), GeneralIndex(9)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X2([Parachain(1000), PalletInstance(9)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(
+			1,
+			X2([Parachain(1000), AccountId32Junction { network: None, id: [1u8; 32] }].into()),
+		);
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+
+		// Other root locations cannot alias anything.
+		let origin = Location::new(1, Here);
+		let target = Location::new(2, X1([GlobalConsensus(Ethereum { chain_id: 1 })].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(2, X2([GlobalConsensus(Kusama), Parachain(1000)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let target = Location::new(0, X2([PalletInstance(8), GeneralIndex(9)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+
+		let origin = Location::new(0, Here);
+		let target = Location::new(1, X1([Parachain(2000)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(1001)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+		let origin = Location::new(1, X1([Parachain(1002)].into()));
+		assert!(!<XcmConfig as xcm_executor::Config>::Aliasers::contains(&origin, &target));
+	});
+}
+
+#[test]
+fn authorized_cross_chain_aliases() {
+	// origin and target are different accounts on different chains
+	let origin: AccountId = [100; 32].into();
+	let bad_origin: AccountId = [150; 32].into();
+	let target: AccountId = [200; 32].into();
+	let fees = POLKADOT_ED * 10;
+
+	let pal_admin = <PenpalA as Chain>::RuntimeOrigin::signed(PenpalAssetOwner::get());
+	PenpalA::mint_foreign_asset(pal_admin.clone(), Location::parent(), origin.clone(), fees * 10);
+	PenpalA::mint_foreign_asset(pal_admin, Location::parent(), bad_origin.clone(), fees * 10);
+	BulletinPolkadot::fund_accounts(vec![(target.clone(), fees * 10)]);
+
+	// let's authorize `origin` on Penpal to alias `target` on Bulletin
+	BulletinPolkadot::execute_with(|| {
+		let penpal_origin = Location::new(
+			1,
+			X2([
+				Parachain(PenpalA::para_id().into()),
+				AccountId32Junction { network: Some(Polkadot), id: origin.clone().into() },
+			]
+			.into()),
+		);
+		// `target` adds `penpal_origin` as authorized alias
+		assert_ok!(
+			<BulletinPolkadot as BulletinPolkadotPallet>::PolkadotXcm::add_authorized_alias(
+				<BulletinPolkadot as Chain>::RuntimeOrigin::signed(target.clone()),
+				Box::new(penpal_origin.into()),
+				None
+			)
+		);
+	});
+	// Verify that unauthorized `bad_origin` cannot alias into `target`, from any chain.
+	test_cross_chain_alias!(
+		vec![
+			// between AH and Bulletin: denied
+			(AssetHubPolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between BH and Bulletin: denied
+			(BridgeHubPolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between People and Bulletin: denied
+			(PeoplePolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between Penpal and Bulletin: denied
+			(PenpalA, BulletinPolkadot, RESERVE_TRANSFER_FEES, DENIED)
+		],
+		bad_origin,
+		target,
+		fees
+	);
+	// Verify that only authorized `penpal::origin` can alias into `target`, while `origin` on other
+	// chains cannot.
+	test_cross_chain_alias!(
+		vec![
+			// between AH and Bulletin: denied
+			(AssetHubPolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between BH and Bulletin: denied
+			(BridgeHubPolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between People and Bulletin: denied
+			(PeoplePolkadot, BulletinPolkadot, TELEPORT_FEES, DENIED),
+			// between Penpal and Bulletin: allowed
+			(PenpalA, BulletinPolkadot, RESERVE_TRANSFER_FEES, ALLOWED)
+		],
+		origin,
+		target,
+		fees
+	);
+	// remove authorization for `origin` on Penpal to alias `target` on Bulletin
+	BulletinPolkadot::execute_with(|| {
+		// `target` removes all authorized aliases
+		assert_ok!(
+			<BulletinPolkadot as BulletinPolkadotPallet>::PolkadotXcm::remove_all_authorized_aliases(
+				<BulletinPolkadot as Chain>::RuntimeOrigin::signed(target.clone())
+			)
+		);
+	});
+	// Verify `penpal::origin` can no longer alias into `target` on Bulletin.
+	test_cross_chain_alias!(
+		vec![(PenpalA, BulletinPolkadot, RESERVE_TRANSFER_FEES, DENIED)],
+		origin,
+		target,
+		fees
+	);
+}

--- a/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/tests/claim_assets.rs
+++ b/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/tests/claim_assets.rs
@@ -1,0 +1,34 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests related to claiming assets trapped during XCM execution.
+
+use crate::*;
+
+use integration_tests_helpers::test_chain_can_claim_assets;
+
+#[test]
+fn assets_can_be_claimed() {
+	let amount = BulletinPolkadotExistentialDeposit::get();
+	let assets: Assets = (Parent, amount).into();
+
+	test_chain_can_claim_assets!(
+		BulletinPolkadot,
+		RuntimeCall,
+		NetworkId::Polkadot,
+		assets,
+		amount
+	);
+}

--- a/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/tests/mod.rs
+++ b/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/tests/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (C) Parity Technologies and the various Polkadot contributors, see Contributions.md
+// for a list of specific contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod aliases;
+mod claim_assets;
+mod teleport;

--- a/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/tests/teleport.rs
+++ b/integration-tests/emulated/tests/bulletin/bulletin-polkadot/src/tests/teleport.rs
@@ -1,0 +1,111 @@
+// Copyright (C) Parity Technologies and the various Polkadot contributors, see Contributions.md
+// for a list of specific contributors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::*;
+use integration_tests_helpers::{
+	test_parachain_is_trusted_teleporter, test_parachain_is_trusted_teleporter_for_relay,
+	test_relay_is_trusted_teleporter,
+};
+
+#[test]
+fn teleport_via_transfer_assets_from_and_to_relay() {
+	let amount = BULLETIN_POLKADOT_ED * 1000;
+	let native_asset: Assets = (Here, amount).into();
+
+	test_relay_is_trusted_teleporter!(
+		Polkadot,
+		vec![BulletinPolkadot],
+		(native_asset, amount),
+		transfer_assets
+	);
+
+	let amount = POLKADOT_ED * 1000;
+
+	test_parachain_is_trusted_teleporter_for_relay!(
+		BulletinPolkadot,
+		Polkadot,
+		amount,
+		transfer_assets
+	);
+}
+
+#[test]
+fn teleport_via_limited_teleport_assets_from_and_to_relay() {
+	let amount = BULLETIN_POLKADOT_ED * 1000;
+	let native_asset: Assets = (Here, amount).into();
+
+	test_relay_is_trusted_teleporter!(
+		Polkadot,
+		vec![BulletinPolkadot],
+		(native_asset, amount),
+		limited_teleport_assets
+	);
+
+	let amount = POLKADOT_ED * 1000;
+
+	test_parachain_is_trusted_teleporter_for_relay!(
+		BulletinPolkadot,
+		Polkadot,
+		amount,
+		limited_teleport_assets
+	);
+}
+
+#[test]
+fn teleport_via_transfer_assets_from_and_to_other_system_parachains_works() {
+	let amount = ASSET_HUB_POLKADOT_ED * 1000;
+	let native_asset: Assets = (Parent, amount).into();
+
+	test_parachain_is_trusted_teleporter!(
+		BulletinPolkadot,
+		vec![AssetHubPolkadot],
+		(native_asset, amount),
+		transfer_assets
+	);
+
+	let amount = BULLETIN_POLKADOT_ED * 1000;
+	let native_asset: Assets = (Parent, amount).into();
+
+	test_parachain_is_trusted_teleporter!(
+		AssetHubPolkadot,
+		vec![BulletinPolkadot],
+		(native_asset, amount),
+		transfer_assets
+	);
+}
+
+#[test]
+fn teleport_via_limited_teleport_assets_from_and_to_other_system_parachains_works() {
+	let amount = ASSET_HUB_POLKADOT_ED * 1000;
+	let native_asset: Assets = (Parent, amount).into();
+
+	test_parachain_is_trusted_teleporter!(
+		BulletinPolkadot,
+		vec![AssetHubPolkadot],
+		(native_asset, amount),
+		limited_teleport_assets
+	);
+
+	let amount = BULLETIN_POLKADOT_ED * 1000;
+	let native_asset: Assets = (Parent, amount).into();
+
+	test_parachain_is_trusted_teleporter!(
+		AssetHubPolkadot,
+		vec![BulletinPolkadot],
+		(native_asset, amount),
+		limited_teleport_assets
+	);
+}

--- a/system-parachains/bulletin/bulletin-polkadot/src/apis.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/apis.rs
@@ -175,7 +175,7 @@ impl_runtime_apis! {
 		fn query_acceptable_payment_assets(
 			xcm_version: xcm::Version
 		) -> Result<Vec<VersionedAssetId>, XcmPaymentApiError> {
-			let acceptable_assets = vec![AssetId(xcm_config::TokenRelayLocation::get())];
+			let acceptable_assets = vec![AssetId(xcm_config::DotLocation::get())];
 			PolkadotXcm::query_acceptable_payment_assets(xcm_version, acceptable_assets)
 		}
 
@@ -350,7 +350,7 @@ impl_runtime_apis! {
 
 			use alloc::boxed::Box;
 			use xcm::latest::prelude::*;
-			use xcm_config::TokenRelayLocation;
+			use xcm_config::DotLocation;
 			use xcm_executor::AssetsInHolding;
 
 			use pallet_xcm::benchmarking::Pallet as PalletXcmExtrinsicsBenchmark;
@@ -365,7 +365,7 @@ impl_runtime_apis! {
 						xcm_config::XcmConfig,
 						ExistentialDepositAsset,
 						PriceForSiblingParachainDelivery,
-						RandomParaId,
+						BenchmarkParaId,
 						ParachainSystem,
 					>
 				);
@@ -375,8 +375,10 @@ impl_runtime_apis! {
 				}
 
 				fn teleportable_asset_and_dest() -> Option<(Asset, Location)> {
-					// Non-system parachains do not support teleports.
-					None
+					Some((
+						Asset { id: AssetId(DotLocation::get()), fun: Fungible(ExistentialDeposit::get()) },
+						xcm_config::AssetHubLocation::get(),
+					))
 				}
 
 				fn reserve_transferable_asset_and_dest() -> Option<(Asset, Location)> {
@@ -399,7 +401,7 @@ impl_runtime_apis! {
 
 			parameter_types! {
 				pub ExistentialDepositAsset: Option<Asset> = Some((
-					TokenRelayLocation::get(),
+					DotLocation::get(),
 					ExistentialDeposit::get()
 				).into());
 			}
@@ -417,32 +419,32 @@ impl_runtime_apis! {
 						xcm_config::XcmConfig,
 						ExistentialDepositAsset,
 						PriceForSiblingParachainDelivery,
-						RandomParaId,
+						BenchmarkParaId,
 						ParachainSystem,
 					>
 				);
 
 				type AccountIdConverter = xcm_config::LocationToAccountId;
 				fn valid_destination() -> Result<Location, BenchmarkError> {
-					Ok(TokenRelayLocation::get())
+					Ok(DotLocation::get())
 				}
 				fn worst_case_holding(_depositable_count: u32) -> AssetsInHolding {
 					use pallet_xcm_benchmarks::MockCredit;
 					// just concrete assets according to relay chain.
 					AssetsInHolding::new_from_fungible_credit(
-						AssetId(TokenRelayLocation::get()),
+						AssetId(DotLocation::get()),
 						Box::new(MockCredit(1_000_000 * UNITS)),
 					)
 				}
 			}
 
 			parameter_types! {
-				pub const TrustedTeleporter: Option<(Location, Asset)> = None;
-				pub const CheckedAccount: Option<(AccountId, xcm_builder::MintLocation)> = None;
-				pub const TrustedReserve: Option<(Location, Asset)> = Some((
-					TokenRelayLocation::get(),
-					Asset { fun: Fungible(UNITS), id: AssetId(TokenRelayLocation::get()) },
+				pub TrustedTeleporter: Option<(Location, Asset)> = Some((
+					xcm_config::AssetHubLocation::get(),
+					Asset { fun: Fungible(UNITS), id: AssetId(DotLocation::get()) },
 				));
+				pub const CheckedAccount: Option<(AccountId, xcm_builder::MintLocation)> = None;
+				pub const TrustedReserve: Option<(Location, Asset)> = None;
 			}
 
 			impl pallet_xcm_benchmarks::fungible::Config for Runtime {
@@ -454,7 +456,7 @@ impl_runtime_apis! {
 
 				fn get_asset() -> Asset {
 					Asset {
-						id: AssetId(TokenRelayLocation::get()),
+						id: AssetId(DotLocation::get()),
 						fun: Fungible(UNITS),
 					}
 				}
@@ -477,23 +479,23 @@ impl_runtime_apis! {
 				}
 
 				fn transact_origin_and_runtime_call() -> Result<(Location, RuntimeCall), BenchmarkError> {
-					Ok((TokenRelayLocation::get(), frame_system::Call::remark_with_event { remark: vec![] }.into()))
+					Ok((DotLocation::get(), frame_system::Call::remark_with_event { remark: vec![] }.into()))
 				}
 
 				fn subscribe_origin() -> Result<Location, BenchmarkError> {
-					Ok(TokenRelayLocation::get())
+					Ok(DotLocation::get())
 				}
 
 				fn claimable_asset() -> Result<(Location, Location, Assets), BenchmarkError> {
-					let origin = TokenRelayLocation::get();
-					let assets: Assets = (AssetId(TokenRelayLocation::get()), 1_000 * UNITS).into();
+					let origin = DotLocation::get();
+					let assets: Assets = (AssetId(DotLocation::get()), 1_000 * UNITS).into();
 					let ticket = Location { parents: 0, interior: Here };
 					Ok((origin, ticket, assets))
 				}
 
 				fn worst_case_for_trader() -> Result<(Asset, WeightLimit), BenchmarkError> {
 					Ok((Asset {
-						id: AssetId(TokenRelayLocation::get()),
+						id: AssetId(DotLocation::get()),
 						fun: Fungible(1_000_000 * UNITS),
 					}, WeightLimit::Limited(Weight::from_parts(5000, 5000))))
 				}

--- a/system-parachains/bulletin/bulletin-polkadot/src/genesis_config_presets.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/genesis_config_presets.rs
@@ -20,25 +20,14 @@ use alloc::{vec, vec::Vec};
 use cumulus_primitives_core::ParaId;
 use frame_support::build_struct_json_patch;
 use parachains_common::{AccountId, AuraId};
-use sp_core::{sr25519, Pair};
 use sp_genesis_builder::PresetId;
 use sp_keyring::Sr25519Keyring;
-use sp_runtime::traits::{IdentifyAccount, Verify};
 use system_parachains_constants::{
 	genesis_presets::SAFE_XCM_VERSION, polkadot::currency::UNITS as DOT,
 };
 
-/// Generate an account ID from a seed string (e.g. `"//Chunkedsigner"`).
-fn account_id_from_seed(seed: &str) -> AccountId {
-	type AccountPublic = <Signature as Verify>::Signer;
-	let public = sr25519::Pair::from_string(seed, None)
-		.expect("static values are valid; qed")
-		.public();
-	AccountPublic::from(public).into_account()
-}
-
 const BULLETIN_POLKADOT_ED: Balance = ExistentialDeposit::get();
-pub const BULLETIN_PARA_ID: ParaId = ParaId::new(2487);
+pub const BULLETIN_PARA_ID: ParaId = ParaId::new(1006);
 
 fn bulletin_polkadot_genesis(
 	invulnerables: Vec<(AccountId, AuraId)>,
@@ -46,7 +35,6 @@ fn bulletin_polkadot_genesis(
 	endowment: Balance,
 	id: ParaId,
 ) -> serde_json::Value {
-	let _ = account_id_from_seed; // suppress unused warning until transaction_storage is re-added
 	build_struct_json_patch!(RuntimeGenesisConfig {
 		balances: BalancesConfig {
 			balances: endowed_accounts.iter().cloned().map(|k| (k, endowment)).collect(),

--- a/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/lib.rs
@@ -80,7 +80,7 @@ use system_parachains_constants::{
 use weights::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight};
 use xcm::{prelude::*, Version as XcmVersion};
 use xcm_config::{
-	AssetHubLocation, FellowshipLocation, RelayChainLocation, TokenRelayLocation,
+	AssetHubLocation, DotLocation, FellowshipLocation, RelayChainLocation,
 	XcmOriginToTransactDispatchOrigin,
 };
 use xcm_runtime_apis::{
@@ -303,7 +303,8 @@ impl pallet_authorship::Config for Runtime {
 
 parameter_types! {
 	pub const ExistentialDeposit: Balance = SYSTEM_PARA_EXISTENTIAL_DEPOSIT;
-	pub const RandomParaId: ParaId = ParaId::new(43211234);
+	/// Arbitrary parachain ID used for benchmark delivery helpers.
+	pub const BenchmarkParaId: ParaId = ParaId::new(43211234);
 }
 
 impl pallet_balances::Config for Runtime {
@@ -416,7 +417,7 @@ pub type RootOrFellows = EitherOfDiverse<
 
 parameter_types! {
 	/// The asset ID for the asset that we use to pay for message delivery fees.
-	pub FeeAssetId: AssetId = AssetId(TokenRelayLocation::get());
+	pub FeeAssetId: AssetId = AssetId(DotLocation::get());
 	/// The base fee for the message delivery fees.
 	pub const BaseDeliveryFee: u128 = CENTS.saturating_mul(3);
 }

--- a/system-parachains/bulletin/bulletin-polkadot/src/xcm_config.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/src/xcm_config.rs
@@ -16,8 +16,8 @@
 
 //! XCM Configuration for Bulletin Polkadot Parachain
 //!
-//! As a non-system parachain, this runtime:
-//! - Uses Asset Hub as the reserve location for DOT (no teleports)
+//! As a system parachain, this runtime:
+//! - Supports DOT teleports with the relay chain and system parachains
 //! - Trusts Asset Hub as the governance location (not the relay)
 
 use super::{
@@ -38,7 +38,7 @@ use pallet_xcm::{AuthorizedAliasers, XcmPassthrough};
 use parachains_common::{
 	xcm_config::{
 		AliasAccountId32FromSiblingSystemChain, AllSiblingSystemParachains,
-		ParentRelayOrSiblingParachains, RelayOrOtherSystemParachains,
+		ConcreteAssetFromSystem, ParentRelayOrSiblingParachains, RelayOrOtherSystemParachains,
 	},
 	TREASURY_PALLET_ID,
 };
@@ -70,16 +70,15 @@ pub mod polkadot_system_parachain {
 	pub const PEOPLE_ID: u32 = 1004;
 	/// Coretime parachain ID.
 	pub const CORETIME_ID: u32 = 1005;
+	/// Bulletin parachain ID.
+	pub const BULLETIN_ID: u32 = 1006;
 }
 
 use polkadot_system_parachain::{ASSET_HUB_ID, COLLECTIVES_ID, PEOPLE_ID};
 
-/// Polkadot Treasury pallet ID (index 19 on Polkadot relay chain).
-pub const TREASURY_PALLET_ID_ON_RELAY: u8 = 19;
-
 parameter_types! {
 	pub const RootLocation: Location = Location::here();
-	pub const TokenRelayLocation: Location = Location::parent();
+	pub const DotLocation: Location = Location::parent();
 	pub const RelayChainLocation: Location = Location::parent();
 	pub AssetHubLocation: Location = Location::new(1, [Parachain(ASSET_HUB_ID)]);
 	// Polkadot network uses the `Polkadot` NetworkId variant
@@ -109,7 +108,7 @@ pub type FungibleTransactor = FungibleAdapter<
 	// Use this currency:
 	Balances,
 	// Use this currency when it is a fungible asset matching the given location or name:
-	IsConcrete<TokenRelayLocation>,
+	IsConcrete<DotLocation>,
 	// Do a simple punn to convert an `AccountId32` `Location` into a native chain
 	// `AccountId`:
 	LocationToAccountId,
@@ -198,40 +197,15 @@ pub type Barrier = TrailingSetTopicAsId<
 
 parameter_types! {
 	pub TreasuryAccount: AccountId = TREASURY_PALLET_ID.into_account_truncating();
-	pub RelayTreasuryLocation: Location = (Parent, PalletInstance(TREASURY_PALLET_ID_ON_RELAY)).into();
 }
 
 /// Locations that will not be charged fees in the executor, neither for execution nor delivery.
 /// We only waive fees for system functions, which these locations represent.
-pub type WaivedLocations = (
-	Equals<RootLocation>,
-	RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>,
-	Equals<RelayTreasuryLocation>,
-	Equals<AssetHubLocation>,
-);
+pub type WaivedLocations =
+	(Equals<RootLocation>, RelayOrOtherSystemParachains<AllSiblingSystemParachains, Runtime>);
 
-/// Helper type to match DOT (relay native token) from Asset Hub.
-pub struct IsRelayTokenFrom<Origin>(core::marker::PhantomData<Origin>);
-impl<Origin> frame_support::traits::ContainsPair<Asset, Location> for IsRelayTokenFrom<Origin>
-where
-	Origin: frame_support::traits::Get<Location>,
-{
-	fn contains(asset: &Asset, origin: &Location) -> bool {
-		let loc = Origin::get();
-		&loc == origin &&
-			matches!(
-				asset,
-				Asset { id: AssetId(asset_id_location), fun: Fungible(_) }
-					if *asset_id_location == TokenRelayLocation::get()
-			)
-	}
-}
-
-/// Reserve locations for assets (Asset Hub for DOT).
-pub type Reserves = IsRelayTokenFrom<AssetHubLocation>;
-
-/// No trusted teleporters.
-pub type TrustedTeleporters = ();
+/// Trusted teleporters for DOT from the relay chain and system parachains.
+pub type TrustedTeleporters = ConcreteAssetFromSystem<DotLocation>;
 
 /// Defines origin aliasing rules for this chain.
 ///
@@ -253,7 +227,7 @@ impl xcm_executor::Config for XcmConfig {
 	type XcmEventEmitter = PolkadotXcm;
 	type AssetTransactor = AssetTransactors;
 	type OriginConverter = XcmOriginToTransactDispatchOrigin;
-	type IsReserve = Reserves;
+	type IsReserve = ();
 	type IsTeleporter = TrustedTeleporters;
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
@@ -264,7 +238,7 @@ impl xcm_executor::Config for XcmConfig {
 	>;
 	type Trader = UsingComponents<
 		WeightToFee,
-		TokenRelayLocation,
+		DotLocation,
 		AccountId,
 		Balances,
 		ResolveTo<StakingPotAccountId<Runtime>, Balances>,
@@ -324,8 +298,8 @@ impl pallet_xcm::Config for Runtime {
 	type ExecuteXcmOrigin = EnsureXcmOrigin<RuntimeOrigin, LocalOriginToLocation>;
 	type XcmExecuteFilter = Everything;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type XcmTeleportFilter = Nothing;
-	type XcmReserveTransferFilter = Everything;
+	type XcmTeleportFilter = Everything;
+	type XcmReserveTransferFilter = Nothing;
 	type Weigher = WeightInfoBounds<
 		crate::weights::xcm::BulletinPolkadotXcmWeight<RuntimeCall>,
 		RuntimeCall,

--- a/system-parachains/bulletin/bulletin-polkadot/tests/tests.rs
+++ b/system-parachains/bulletin/bulletin-polkadot/tests/tests.rs
@@ -28,7 +28,7 @@ use parachains_common::{AccountId, AuraId, Hash as PcHash, Signature as PcSignat
 use parachains_runtimes_test_utils::{ExtBuilder, GovernanceOrigin, RuntimeHelper};
 use sp_core::{crypto::Ss58Codec, Encode, Pair};
 use sp_keyring::Sr25519Keyring;
-use sp_runtime::{transaction_validity, ApplyExtrinsicResult, BuildStorage, Either};
+use sp_runtime::{transaction_validity, BuildStorage, Either};
 use xcm::latest::prelude::*;
 use xcm_runtime_apis::conversions::LocationToAccountHelper;
 
@@ -77,14 +77,6 @@ fn construct_extrinsic(
 		// Unsigned call.
 		Ok(UncheckedExtrinsic::new_transaction(call, tx_ext))
 	}
-}
-
-fn construct_and_apply_extrinsic(
-	account: Option<sp_core::sr25519::Pair>,
-	call: RuntimeCall,
-) -> ApplyExtrinsicResult {
-	let xt = construct_extrinsic(account, call)?;
-	bulletin_polkadot_runtime::Executive::apply_extrinsic(xt)
 }
 
 #[test]


### PR DESCRIPTION
- Changed Bulletin's ParaId to 1006 (< 2000 means system parachain)
- Changed allowed reserve transfers to/from Asset Hub to teleports with any part of the system
- Emulated tests for teleports, claims and aliases
- Some cleanups and renames
